### PR TITLE
Explicitly set GitHub URL in navbar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
         <li><a href="features">Features</a></li>
         <li><a href="songs">Songs</a></li>
         <li><a href="nbs">Format</a></li>
-        <li><a href="{{ site.github.repository_url }}">GitHub</a></li>
+        <li><a href="https://github.com/OpenNBS">GitHub</a></li>
         <li><a href="signin" id="signInLink" class="signInTextChange">Sign In</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
Currently, the GitHub link in the navbar brings you to this repository. Ideally, since this is an organization with many repositories, it'd link to the organization page instead.