### PR TITLE
Remove newversion class from layer volume

### DIFF
--- a/pages/nbs.md
+++ b/pages/nbs.md
@@ -281,7 +281,7 @@ permalink: /nbs
 						<td>Layer lock</td>
 						<td>Whether or not this layer has been marked as locked. 1 = locked.</td>
 					</tr>
-					<tr class="newversion">
+					<tr>
 						<td>Byte</td>
 						<td>Layer volume</td>
 						<td>The volume of the layer (percentage). Ranges from 0-100.</td>


### PR DESCRIPTION
Layer volume isn't a part of the new format, and has always been there.

See https://web.archive.org/web/20151224185030/https://www.stuffbydavid.com/mcnbs/format